### PR TITLE
Fix the extra 0xff bug and add some options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ Building
 ========
 
 The project was created in Xcode 5 on Mac OS X but the C file should compile on pretty much any system with an ANSI C compiler.
+It's also known to work on Gentoo with gcc 5.4.0.
 
 
 Usage
 =====
 
-`bin2c [-i inputfile] [-o output.h] [-l line_len] [-t type] -a array_name`
+`bin2c [-i inputfile] [-o output.h] [-l line_len] [-t type] [-hs0] -a array_name`
+-h: show a brief help message
+-s: prepend the 'static' keyword to the generated variables
+-0: when -t char, add a null-char at the end of the array
 
 If no output file is specified, the C array will be sent on the standard output. Likewise, if no input file is given, data is read from the standard input.
 

--- a/bin2c/main.c
+++ b/bin2c/main.c
@@ -55,13 +55,14 @@ void bin2c(const char *infile, const char *outfile, const char *array, const Out
                 fprintf(out, "%sconst NSString *%s = \n\t@\"", static_str, array);
             }
 
+            c = fgetc(in);
             while (!feof(in)) {
-                c = fgetc(in);
                 l++;
                 fprintf(out, "\\x%02x", c);
                 if ((l % opts->line_len) == 0) {
                     fprintf(out, "\"\n\t\"");
                 }
+                c = fgetc(in);
             }
             fprintf(out, "\";\n\n");
             if (out != stdout)

--- a/bin2c/main.c
+++ b/bin2c/main.c
@@ -17,39 +17,49 @@ typedef enum
     VTNSString
 } VariableType;
 
+typedef struct
+{
+    VariableType vtype;
+    int static_keyword;
+    int line_len;
+} OutOptions;
+
 static void print_usage(const char *argv0)
 {
     fprintf(stderr,
-            "Usage: %s [-i inputfile] [-o output.h] [-l line_len] [-t type] -a var_name\n"
+            "Usage: %s [-i inputfile] [-o output.h] [-l line_len] [-t type] [-sh] -a var_name\n"
+            "\t-s make the generated variable static\n"
+            "\t-h show this help\n"
             "\ttype can be: char (unsigned char array, default), nsstring (Objective-C NSString constant)\n",
             argv0);
     exit(1);
 }
 
-void bin2c(const char *infile, const char *outfile, const char *array, int line_len, VariableType vtype)
+void bin2c(const char *infile, const char *outfile, const char *array, const OutOptions* opts)
 {
     FILE *in, *out;
-    
+    const char* const static_str = (opts->static_keyword ? "static " : "");
+
     in = infile ? fopen(infile, "rb") : stdin;
     if (in) {
         out = outfile ? fopen(outfile, "w") : stdout;
         if (out) {
             unsigned char c;
             unsigned int l = 0;
-            
+
             if (infile)
                 fprintf(out, "// Imported from file '%s'\n", infile);
-            if (vtype == VTChar) {
-                fprintf(out, "static const unsigned char %s[] = \n\t\"", array);
+            if (opts->vtype == VTChar) {
+                fprintf(out, "%sconst unsigned char %s[] = \n\t\"", static_str, array);
             } else { // NSString
-                fprintf(out, "static const NSString *%s = \n\t@\"", array);
+                fprintf(out, "%sconst NSString *%s = \n\t@\"", static_str, array);
             }
-            
+
             while (!feof(in)) {
                 c = fgetc(in);
                 l++;
                 fprintf(out, "\\x%02x", c);
-                if ((l % line_len) == 0) {
+                if ((l % opts->line_len) == 0) {
                     fprintf(out, "\"\n\t\"");
                 }
             }
@@ -70,10 +80,14 @@ int main(int argc,  char * const argv[])
 {
     const char *infile = NULL, *outfile = NULL, *array = NULL;
     int line_len = 80;
-    VariableType vtype = VTChar;
+    OutOptions opts;
     int opt;
-    
-    while( (opt = getopt(argc, argv, "i:o:a:l:t:")) != -1) {
+
+    opts.vtype = VTChar;
+    opts.static_keyword = 0;
+    opts.line_len = 80;
+
+    while( (opt = getopt(argc, argv, "i:o:a:l:t:sh")) != -1) {
         switch (opt) {
             case 'i':
                 infile = strdup(optarg);
@@ -85,29 +99,32 @@ int main(int argc,  char * const argv[])
                 array = strdup(optarg);
                 break;
             case 'l':
-                line_len = atoi(optarg);
+                opts.line_len = atoi(optarg);
                 break;
             case 't':
                 if (!strcmp(optarg, "char")) {
-                    vtype = VTChar;
+                    opts.vtype = VTChar;
                 } else if (!strcmp(optarg, "nsstring")) {
-                    vtype = VTNSString;
+                    opts.vtype = VTNSString;
                 } else {
                     print_usage(argv[0]);
                 }
                 break;
+            case 's':
+                opts.static_keyword = 1;
+                break;
+            case 'h':
             default:
                 print_usage(argv[0]);
                 break;
         }
     }
-    
+
     if (!array) {
         print_usage(argv[0]);
     } else {
-        bin2c(infile, outfile, array, line_len, vtype);
+        bin2c(infile, outfile, array, &opts);
     }
-    
+
     return 0;
 }
-


### PR DESCRIPTION
In my project I need to generate c-style arrays from arbitrary data, similarly to what xxd does. In my current version:

- there is no extra 0xff at the end data 
- c-style arrays are printed in the form:
`unsigned char a[] = {
    0x01,0x02
};
`
with an optional 0x00 at the end (-0 switch)

- c-style arrays also come with an unsigned int initialized to the length of the corresponding array (original array name + _len suffix)
- nsstrings are left untouched
- the 'static' keyword is now optional (-s switch) and it's disabled by default
- the tool understands the -h switch so it doesn't print an error message when showing the help summary